### PR TITLE
Adding shebang pointing to env python3

### DIFF
--- a/unhoster.py
+++ b/unhoster.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 from json import load
 import pprint


### PR DESCRIPTION
I keep forgetting to run

```
python unhoster.py
```

so I just added this shebang line that should work most places (and works for me in Cygwin).
