### PR TITLE
Make `open` independent of default encoding

### DIFF
--- a/unhoster.py
+++ b/unhoster.py
@@ -39,7 +39,7 @@ def url_to_tts(url):
     return "".join([c for c in url if c.isalpha() or c.isdigit()]).rstrip() + url_ext
 
 def parse_tts_custom_object(workshop_json):
-    with open(workshop_json, "r") as fp:
+    with open(workshop_json, "r", encoding="utf-8") as fp:
         save = load(fp)
         objects = save["ObjectStates"]
 
@@ -79,7 +79,7 @@ if __name__ == '__main__':
     if len(args.json_input) == 1 and os.path.basename(args.json_input[0]) == "WorkshopFileInfos.json": # this wont ever break, ever! please
         print("Loaded WorkshopFileInfos.json; listing json names")
 
-        with open(args.json_input[0], "r") as fp:
+        with open(args.json_input[0], "r", encoding="utf-8") as fp:
             file_infos = load(fp)
 
         name_map = {}


### PR DESCRIPTION
In python3, default encoding of `open()` comes from `locale.getpreferredencoding()`.
And it was not utf-8 in my case (cp949), which caused error while reading `WorkshopFileInfos.json` on line 83 (since the file was encoded in utf-8 and contained non-ascii characters).
In order to resolve this issue, I explicitly set encoding to utf-8 whenever reading non-binary text files.